### PR TITLE
#3 [FEA-001] Integração com API do Jobicy

### DIFF
--- a/.github/workflows/job.yaml
+++ b/.github/workflows/job.yaml
@@ -43,4 +43,4 @@ jobs:
           JOB_LIMIT: ${{ secrets.JOB_LIMIT }}
           RESUME_FILE_PATH: ${{secrets.RESUME_FILE_PATH}}
           JOBICY_RSS_URL: ${{secrets.JOBICY_RSS_URL}}
-          WWR_RSS_URL: ${{secrets.WWR_RSS_URL}}
+          # WWR_RSS_URL: ${{secrets.WWR_RSS_URL}}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jobs Bot
 
-The Jobs Bot is a bot that searches for new job openings on LinkedIn, WeWorkRemotely, and Jobicy through an RSS feed, filters the jobs based on keywords, analyzes compatibility with your resume, and sends the best ones to a Trello board.
+The Jobs Bot is a bot that searches for new job openings on LinkedIn and WeWorkRemotely through an RSS feed, and on Jobicy through its JSON API. It then filters the jobs based on keywords, analyzes compatibility with your resume, and sends the best ones to a Trello board.
 
 ## Architecture
 

--- a/docs/pt-br/README.md
+++ b/docs/pt-br/README.md
@@ -1,6 +1,6 @@
 # Jobs Bot
 
-O Jobs Bot é um bot que busca novas vagas de emprego no LinkedIn, WeWorkRemotely e Jobicy através de um feed RSS, filtra as vagas com base em palavras-chave, analisa a compatibilidade com o seu currículo e envia as melhores para um quadro do Trello.
+O Jobs Bot é um bot que busca novas vagas de emprego no LinkedIn e WeWorkRemotely através de um feed RSS, e no Jobicy através de sua API JSON. Ele então filtra as vagas com base em palavras-chave, analisa a compatibilidade com o seu currículo e envia as melhores para um quadro do Trello.
 
 ## Arquitetura
 


### PR DESCRIPTION
## Resumo do Pull Request

Este PR refatora a integração com a fonte de vagas Jobicy, substituindo a busca baseada em RSS por uma integração direta com a API JSON da plataforma. Essa mudança torna a coleta de dados mais robusta e confiável.

### Principais Alterações:

#### 1. Mudança da Fonte de Dados para API JSON

- **Fonte de Dados:** A busca de vagas do Jobicy foi atualizada para consumir a API JSON em vez do feed RSS.
- **Estruturas de Dados:** As `structs` `jobicyItem` e `jobicyRss` foram substituídas por `jobicyAPIResponse` e `jobicyJob` para mapear a resposta da API JSON.
- **Decodificação:** O decodificador XML foi substituído pelo decodificador JSON para processar os dados da API.

#### 2. Aprimoramentos na Requisição HTTP

- **User-Agent:** A requisição HTTP agora inclui um `User-Agent` para simular um navegador, o que pode ser necessário para acessar a API do Jobicy sem restrições.

#### 3. Mapeamento de Dados

- **GUID:** O campo `GUID` do `Job` agora é preenchido com o `ID` da vaga retornado pela API, garantindo um identificador único e consistente.
